### PR TITLE
Include RIFE model in repo

### DIFF
--- a/AnimationKit_Rife_RealESRGAN_Upscaling_Interpolation.ipynb
+++ b/AnimationKit_Rife_RealESRGAN_Upscaling_Interpolation.ipynb
@@ -7,8 +7,7 @@
       "provenance": [],
       "collapsed_sections": [],
       "private_outputs": true,
-      "machine_shape": "hm",
-      "include_colab_link": true
+      "machine_shape": "hm"
     },
     "kernelspec": {
       "name": "python3",
@@ -20,16 +19,6 @@
     "accelerator": "GPU"
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/sadnow/AnimationKit-AI/blob/main/AnimationKit_Rife_RealESRGAN_Upscaling_Interpolation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -175,8 +164,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "4hULXQndE4xk",
-        "cellView": "form"
+        "id": "4hULXQndE4xk"
       },
       "source": [
         "#@title  { form-width: \"300px\" }\n",
@@ -326,7 +314,7 @@
         "    #!git clone https://github.com/hzwer/Practical-RIFE Practical-RIFE &> /dev/null  #using my own archive for longevity\n",
         "    !git clone https://github.com/sadnow/Practical-RIFE_AnimationKit Practical-RIFE &> /dev/null  #using my own archive for longevity\n",
         "    #!gdown --id 1O5KfS3KzZCY3imeCr2LCsntLhutKuAqj &> /dev/null  #DEPRECATED 3.8 MODEL\n",
-        "    !gdown --id 1mUK9iON6Es14oK46-cCflRoPTeGiI_A9 &> /dev/null  #NEWER 4.0 MODEL\n",
+        "    !curl -L https://github.com/chigozienri/AnimationKit-AI/blob/main/RIFE_trained_model_v4.0.zip?raw=true > RIFE_trained_model_v4.0.zip  #NEWER 4.0 MODEL\n",
         "    #!7z e RIFE_trained_model_v3.8.zip &> /dev/null\n",
         "    !7z e RIFE_trained_model_v4.0.zip &> /dev/null\n",
         "    !mkdir /content/Practical-RIFE/train_log  &> /dev/null\n",
@@ -386,7 +374,7 @@
         "#If RIFE (P2) stops for no reason, go to Runtime>Change Runtime type and set the notebook to \"high memory\"\n",
         "\n",
         "#Params\n",
-        "mount_google_drive = True #@param {type:\"boolean\"}\n",
+        "mount_google_drive = False #@param {type:\"boolean\"}\n",
         "\n",
         "#Mount Google Drive\n",
         "if mount_google_drive:\n",

--- a/AnimationKit_Rife_RealESRGAN_Upscaling_Interpolation.ipynb
+++ b/AnimationKit_Rife_RealESRGAN_Upscaling_Interpolation.ipynb
@@ -164,7 +164,8 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "4hULXQndE4xk"
+        "id": "4hULXQndE4xk",
+        "cellView": "form"
       },
       "source": [
         "#@title  { form-width: \"300px\" }\n",
@@ -374,7 +375,7 @@
         "#If RIFE (P2) stops for no reason, go to Runtime>Change Runtime type and set the notebook to \"high memory\"\n",
         "\n",
         "#Params\n",
-        "mount_google_drive = False #@param {type:\"boolean\"}\n",
+        "mount_google_drive = True #@param {type:\"boolean\"}\n",
         "\n",
         "#Mount Google Drive\n",
         "if mount_google_drive:\n",


### PR DESCRIPTION
The google drive version of the RIFE model can no longer be downloaded programatically, so the notebook fails to run. This PR mirrors the RIFE model here and uses the mirrored version instead.